### PR TITLE
fix(ts): npm script fixed not to publish an empty lib folder

### DIFF
--- a/malai-core/org.malai.ts/package-lock.json
+++ b/malai-core/org.malai.ts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "org.malai.ts",
-  "version": "3.1.0-alpha.1.2.3",
+  "version": "3.1.0-alpha.1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/malai-core/org.malai.ts/package.json
+++ b/malai-core/org.malai.ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "org.malai.ts",
   "description": "The typescript implementation of Malai (WIP)",
-  "version": "3.1.0-alpha.1.0.0",
+  "version": "3.1.0-alpha.1.2.5",
   "author": "Arnaud Blouin",
   "contributors": [
     "Gwendal Didot <didotgwendal@gmail.com>"
@@ -24,11 +24,11 @@
     "typescript": "^2.8.1"
   },
   "scripts": {
-    "lib-build": "npm run prepare && npm run build && npm run clean_after",
+    "lib-build": "npm run pre-build && npm run build && npm run clean_after",
     "build": "rollup -c",
     "generates-barrels": "barrelsby -c ./barrelsby-config.json --delete",
     "compile": "tsc",
-    "prepare": "npm run clean && npm run compile && npm run coverage && npm run lint",
+    "pre-build": "npm run clean && npm run compile && npm run coverage && npm run lint",
     "clean": "rm -rf coverage/* lib/*",
     "clean_after": "rm -rf compiled_inter",
     "test": "jest",


### PR DESCRIPTION
Just a small change of name for the script in package.json to avoid publish an empty lib folder on npm