### PR TITLE
new(ts): Adding a method to get the 'currentTarget' of an event

### DIFF
--- a/malai-core/org.malai.ts/src/interaction/library/DragLock.ts
+++ b/malai-core/org.malai.ts/src/interaction/library/DragLock.ts
@@ -203,4 +203,8 @@ export class DragLock extends TSInteraction<SrcTgtPointsData, DragLockFSM, Event
     public getSrcScreenY(): number {
         return this.firstClick.getData().getSrcScreenY();
     }
+
+    public getCurrentTarget(): Optional<EventTarget> {
+        return this.firstClick.getData().getCurrentTarget();
+    }
 }

--- a/malai-core/org.malai.ts/src/interaction/library/PointData.ts
+++ b/malai-core/org.malai.ts/src/interaction/library/PointData.ts
@@ -61,4 +61,6 @@ export interface PointData {
      * @return The object picked at the pressed position.
      */
     getSrcObject(): Optional<EventTarget>;
+
+    getCurrentTarget(): Optional<EventTarget>;
 }

--- a/malai-core/org.malai.ts/src/interaction/library/PointDataImpl.ts
+++ b/malai-core/org.malai.ts/src/interaction/library/PointDataImpl.ts
@@ -36,6 +36,8 @@ export class PointDataImpl implements PointData {
     /** The object picked at the pressed position. */
     protected srcObject: EventTarget | undefined;
 
+    protected currentTarget: EventTarget | undefined;
+
     public constructor() {
     }
 
@@ -101,6 +103,10 @@ export class PointDataImpl implements PointData {
         this.srcClientY = event.clientY;
         this.button = event.button;
         this.srcObject = event.target === null ? undefined : event.target;
+        this.currentTarget = event.currentTarget === null ? undefined : event.currentTarget;
         this.setModifiersData(event);
+    }
+    public getCurrentTarget(): Optional<EventTarget> {
+        return Optional.ofNullable(this.currentTarget);
     }
 }

--- a/malai-core/org.malai.ts/src/interaction/library/PointInteraction.ts
+++ b/malai-core/org.malai.ts/src/interaction/library/PointInteraction.ts
@@ -71,4 +71,8 @@ export abstract class PointInteraction<D extends PointData, F extends FSM<Event>
     public isShiftPressed(): boolean {
         return this.pointData.isShiftPressed();
     }
+
+    public getCurrentTarget(): Optional<EventTarget> {
+        return this.pointData.getCurrentTarget();
+    }
 }

--- a/malai-core/org.malai.ts/test/interaction/ClickCurrentTarget.test.ts
+++ b/malai-core/org.malai.ts/test/interaction/ClickCurrentTarget.test.ts
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Malai.
+ * Copyright (c) 2009-2018 Arnaud BLOUIN
+ * Malai is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ * Malai is distributed without any warranty; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ */
+
+import {FSMHandler} from "../../src/src-core/fsm/FSMHandler";
+import {StubFSMHandler} from "../fsm/StubFSMHandler";
+import {Click} from "../../src/interaction/library/Click";
+import {createMouseEvent} from "./StubEvents";
+
+jest.mock("../fsm/StubFSMHandler");
+
+let interaction: Click;
+let groupe: HTMLElement;
+let circle: HTMLElement;
+let handler: FSMHandler;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    handler = new StubFSMHandler();
+    interaction = new Click();
+    interaction.log(true);
+    interaction.getFsm().log(true);
+    interaction.getFsm().addHandler(handler);
+    document.documentElement.innerHTML = "<html><svg><g id='gro'><circle r=\"1\" id='circle'></circle><text></text></g></svg></html>";
+    const elt = document.getElementById("gro");
+    const elt2 = document.getElementById("circle");
+    if (elt && elt2 !== null) {
+        groupe = elt;
+        circle = elt2;
+    }
+});
+
+test("Test current target with group tag", () => {
+    interaction.registerToNodes([groupe]);
+    circle.dispatchEvent(createMouseEvent("click", circle));
+    expect(interaction.pointData.getCurrentTarget().get()).toBe(groupe);
+});


### PR DESCRIPTION
Method use to get currentTarget of event (useful to get parent of event.target)