### PR TITLE
new(ts): Adding to() routine to binder

### DIFF
--- a/malai-core/org.malai.ts/package.json
+++ b/malai-core/org.malai.ts/package.json
@@ -33,7 +33,7 @@
     "clean_after": "rm -rf compiled_inter",
     "test": "jest",
     "lint": "tslint --project tsconfig.json --config tslint.json",
-    "coverage": "jest --coverage --collectCoverageFrom=target/src*/**/*.js",
+    "coverage": "jest --coverage --collectCoverageFrom=src*/**/*.ts",
     "clear-all": "npm run clean && npm run clean_after"
   },
   "files": [
@@ -57,7 +57,7 @@
       "node"
     ],
     "modulePathIgnorePatterns": [
-      "<rootDir>/target"
+      "<rootDir>/compiled_inter"
     ]
   }
 }

--- a/malai-core/org.malai.ts/src/binding/AnonCmdBinder.ts
+++ b/malai-core/org.malai.ts/src/binding/AnonCmdBinder.ts
@@ -27,6 +27,6 @@ export class AnonCmdBinder<I extends TSInteraction<D, FSM<Event>, {}>, D extends
     public bind(): TSWidgetBinding<AnonCmd, I, D> {
         return new AnonNodeBinding(false, this.interaction, this.cmdProducer, () => {},
             () => {}, this.checkConditions, this.onEnd, () => {}, () => {}, () => {},
-            this.widgets, this.additionalWidgets, this._async, false, new Array(...this.logLevels));
+            this.widgets, this.additionalWidgets, this.targetWidgets, this._async, false, new Array(...this.logLevels));
     }
 }

--- a/malai-core/org.malai.ts/src/binding/AnonNodeBinding.ts
+++ b/malai-core/org.malai.ts/src/binding/AnonNodeBinding.ts
@@ -15,6 +15,7 @@ import {LogLevel} from "../src-core/logging/LogLevel";
 import {FSM} from "../src-core/fsm/FSM";
 import {CommandImpl} from "../src-core/command/CommandImpl";
 import {InteractionData} from "../src-core/interaction/InteractionData";
+import {MArray} from "../util/ArrayUtil";
 
 export class AnonNodeBinding<C extends CommandImpl, I extends TSInteraction<D, FSM<Event>, {}>, D extends InteractionData>
     extends TSWidgetBinding<C, I, D> {
@@ -48,7 +49,7 @@ export class AnonNodeBinding<C extends CommandImpl, I extends TSInteraction<D, F
                        updateCmdFct: (i: D, c: C | undefined) => void, check: (i: D) => boolean,
                        onEndFct: (i: D, c: C | undefined) => void, cancel: (i: D, c: C | undefined) => void,
                        endOrCancel: (i: D, c: C | undefined) => void, feedback: () => void, widgets: Array<EventTarget>,
-                       additionalWidgets: Array<Node>,
+                       additionalWidgets: Array<Node>, targetWidgets: MArray<EventTarget>,
                        // List<ObservableList<? extends Node>> additionalWidgets, HelpAnimation animation, help : boolean
                        asyncExec: boolean, strict: boolean, loggers: Array<LogLevel>) {
         super(exec, interaction, cmdProducer, widgets);
@@ -66,6 +67,9 @@ export class AnonNodeBinding<C extends CommandImpl, I extends TSInteraction<D, F
 
         if (additionalWidgets !== undefined) {
             additionalWidgets.filter(value => value !== undefined).forEach(node => interaction.registerToObservableList(node));
+        }
+        if (targetWidgets !== undefined) {
+            interaction.registerToTargetNodes(targetWidgets);
         }
     }
 

--- a/malai-core/org.malai.ts/src/binding/Binder.ts
+++ b/malai-core/org.malai.ts/src/binding/Binder.ts
@@ -32,11 +32,11 @@ export abstract class Binder<C extends CommandImpl, I extends TSInteraction<D, F
     protected checkConditions: (i: D) => boolean;
     protected readonly widgets: MArray<EventTarget>;
     protected additionalWidgets: MArray<Node>;
+    protected targetWidgets: MArray<EventTarget>;
     protected readonly cmdProducer: (i?: D) => C;
     protected readonly interaction: I;
     protected _async: boolean;
     protected onEnd: (i: D, c: C | undefined) => void;
-// protected List<ObservableList<? extends Node>> additionalWidgets;
     protected readonly logLevels: Array<LogLevel>;
 
     protected constructor(interaction: I, cmdProducer: (i?: D) => C) {
@@ -65,6 +65,14 @@ export abstract class Binder<C extends CommandImpl, I extends TSInteraction<D, F
             this.additionalWidgets = new MArray<Node>();
         }
         this.additionalWidgets.push(widget);
+        return this as {} as B;
+    }
+
+    public to(widget: EventTarget) {
+        if (this.targetWidgets === undefined) {
+            this.targetWidgets = new MArray<EventTarget>();
+        }
+        this.targetWidgets.push(widget);
         return this as {} as B;
     }
 
@@ -133,6 +141,6 @@ export abstract class Binder<C extends CommandImpl, I extends TSInteraction<D, F
     public bind(): TSWidgetBinding<C, I, D> {
         return new AnonNodeBinding<C, I, D>(false, this.interaction, this.cmdProducer, this.initCmd, (d: D) => {},
             this.checkConditions, this.onEnd, () => {}, () => {}, () => {},
-            this.widgets, this.additionalWidgets, this._async, false, this.logLevels);
+            this.widgets, this.additionalWidgets, this.targetWidgets, this._async, false, this.logLevels);
     }
 }

--- a/malai-core/org.malai.ts/src/binding/KeyNodeBinder.ts
+++ b/malai-core/org.malai.ts/src/binding/KeyNodeBinder.ts
@@ -33,6 +33,7 @@ export class KeyNodeBinder<C extends CommandImpl> extends KeyBinder<C, KeyNodeBi
             () => {},
             this.widgets,
             this.additionalWidgets,
+            this.targetWidgets,
             this._async,
             false,
             this.logLevels);

--- a/malai-core/org.malai.ts/src/binding/UpdateBinder.ts
+++ b/malai-core/org.malai.ts/src/binding/UpdateBinder.ts
@@ -107,7 +107,7 @@ export abstract class UpdateBinder<C extends CommandImpl, I extends TSInteractio
     public bind(): TSWidgetBinding<C, I, D> {
         return new AnonNodeBinding(this.execOnChanges, this.interaction, this.cmdProducer, this.initCmd, this.updateFct,
             this.checkConditions, this.onEnd, this.cancelFct, this.endOrCancelFct, this.feedbackFct, this.widgets,
-            this.additionalWidgets, this._async,
+            this.additionalWidgets, this.targetWidgets, this._async,
             this._strictStart, new Array(...this.logLevels));
     }
 }

--- a/malai-core/org.malai.ts/src/interaction/TSInteraction.ts
+++ b/malai-core/org.malai.ts/src/interaction/TSInteraction.ts
@@ -20,6 +20,7 @@ import {MArray} from "../util/ArrayUtil";
 export abstract class TSInteraction<D extends InteractionData, F extends FSM<Event>, T> extends InteractionImpl<D, Event, F>
         implements WidgetData<T> {
     protected readonly _registeredNodes: Set<EventTarget>;
+    protected readonly _registeredTargetNode: MArray<EventTarget>;
     public readonly _additionalNodes: MArray<Node>;
     protected readonly listMutationObserver: MArray<MutationObserver>;
     /** The widget used during the interaction. */
@@ -34,6 +35,7 @@ export abstract class TSInteraction<D extends InteractionData, F extends FSM<Eve
         this._registeredNodes = new Set<EventTarget>();
         this._additionalNodes = new MArray<Node>();
         this.listMutationObserver = new MArray<MutationObserver>();
+        this._registeredTargetNode = new MArray<EventTarget>();
     }
 
     /**
@@ -61,6 +63,12 @@ export abstract class TSInteraction<D extends InteractionData, F extends FSM<Eve
             eventsToRemove.forEach(type => this.unregisterEventToNode(type, n));
             eventsToAdd.forEach(type => this.registerEventToNode(type, n));
         });
+        if (newState !== this.fsm.initState) {
+            this._registeredTargetNode.forEach(n => {
+                eventsToRemove.forEach(type => this.unregisterEventToNode(type, n));
+                eventsToAdd.forEach(type => this.registerEventToNode(type, n));
+            });
+        }
     }
 
     private callBackMutationObserver(mutationList: Array<MutationRecord>) {
@@ -81,6 +89,13 @@ export abstract class TSInteraction<D extends InteractionData, F extends FSM<Eve
         });
     }
 
+    public registerToTargetNodes(targetWidgets: Array<EventTarget>): void {
+        targetWidgets.forEach(w => {
+            this._registeredTargetNode.push(w);
+            this.onNewNodeTargetRegistered(w);
+        });
+    }
+
     public unregisterFromNodes(widgets: Array<EventTarget>): void {
         widgets.forEach(w => {
             this._registeredNodes.delete(w);
@@ -94,6 +109,12 @@ export abstract class TSInteraction<D extends InteractionData, F extends FSM<Eve
 
     public onNewNodeRegistered(node: EventTarget): void {
         this.getEventTypesOf(this.fsm.currentState).forEach(type => this.registerEventToNode(type, node));
+    }
+
+    public onNewNodeTargetRegistered(node: EventTarget): void {
+        if (this.fsm.currentState !== this.fsm.initState) {
+            this.getEventTypesOf(this.fsm.currentState).forEach(type => this.registerEventToNode(type, node));
+        }
     }
 
     public registerToObservableList(elementToObserve: Node) {
@@ -223,6 +244,7 @@ export abstract class TSInteraction<D extends InteractionData, F extends FSM<Eve
     public uninstall(): void {
         this._widget = undefined;
         this._registeredNodes.clear();
+        this._additionalNodes.clear();
         super.uninstall();
     }
 }

--- a/malai-core/org.malai.ts/src/interaction/TSInteraction.ts
+++ b/malai-core/org.malai.ts/src/interaction/TSInteraction.ts
@@ -63,9 +63,11 @@ export abstract class TSInteraction<D extends InteractionData, F extends FSM<Eve
             eventsToRemove.forEach(type => this.unregisterEventToNode(type, n));
             eventsToAdd.forEach(type => this.registerEventToNode(type, n));
         });
+        this._registeredTargetNode.forEach(n => {
+            eventsToRemove.forEach(type => this.unregisterEventToNode(type, n));
+        });
         if (newState !== this.fsm.initState) {
             this._registeredTargetNode.forEach(n => {
-                eventsToRemove.forEach(type => this.unregisterEventToNode(type, n));
                 eventsToAdd.forEach(type => this.registerEventToNode(type, n));
             });
         }
@@ -245,6 +247,7 @@ export abstract class TSInteraction<D extends InteractionData, F extends FSM<Eve
         this._widget = undefined;
         this._registeredNodes.clear();
         this._additionalNodes.clear();
+        this._registeredTargetNode.clear();
         super.uninstall();
     }
 }

--- a/malai-core/org.malai.ts/test/binding/Bindings.test.ts
+++ b/malai-core/org.malai.ts/test/binding/Bindings.test.ts
@@ -12,7 +12,8 @@
 import {anonCmdBinder, buttonBinder, nodeBinder} from "../../src/binding/Bindings";
 import {Click} from "../../src/interaction/library/Click";
 import {StubCmd} from "../command/StubCmd";
-import {AnonCmd, MArray} from "../../src";
+import {AnonCmd, DnD, EventRegistrationToken, MArray} from "../../src";
+import {createMouseEvent} from "../interaction/StubEvents";
 
 jest.mock("../command/StubCmd");
 
@@ -59,4 +60,22 @@ test("node binder on multiple target", () => {
     })).on(target).bind();
     // canvas.click();
     button.click();
+});
+
+test("Node binder with the to() routine", () => {
+    nodeBinder(new Click(), () => new StubCmd()).on(button).to(canvas).bind();
+    button.click();
+    canvas.click();
+    expect(StubCmd.prototype.doIt).toHaveBeenCalledTimes(1);
+});
+
+test("nodeBinder with to() routine and DnD interaction", () => {
+    nodeBinder(new DnD(false, false), () => new StubCmd()).on(button).to(canvas).bind();
+    button.dispatchEvent(createMouseEvent(EventRegistrationToken.MouseDown, button));
+    canvas.dispatchEvent(createMouseEvent(EventRegistrationToken.MouseMove, canvas));
+    canvas.dispatchEvent(createMouseEvent(EventRegistrationToken.MouseUp, canvas));
+    canvas.dispatchEvent(createMouseEvent(EventRegistrationToken.MouseDown, canvas));
+    button.dispatchEvent(createMouseEvent(EventRegistrationToken.MouseMove, button));
+    button.dispatchEvent(createMouseEvent(EventRegistrationToken.MouseUp, button));
+    expect(StubCmd.prototype.doIt).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
Add a way to explicitly give to the interaction bind elements on which it should be update, but never start.
Also change jest config to properly cover source files.