### PR TITLE
fix(ts): fixing TSInteraction's additionalNodes behavior

### DIFF
--- a/malai-core/org.malai.ts/src/binding/AnonNodeBinding.ts
+++ b/malai-core/org.malai.ts/src/binding/AnonNodeBinding.ts
@@ -66,7 +66,9 @@ export class AnonNodeBinding<C extends CommandImpl, I extends TSInteraction<D, F
         this.configureLoggers(loggers);
 
         if (additionalWidgets !== undefined) {
-            additionalWidgets.filter(value => value !== undefined).forEach(node => interaction.registerToObservableList(node));
+            const noUndefinedWidget = additionalWidgets.filter(value => value !== undefined);
+            noUndefinedWidget.forEach(node => interaction.registerToObservableList(node));
+            interaction.addAdditionalNodes(noUndefinedWidget);
         }
         if (targetWidgets !== undefined) {
             interaction.registerToTargetNodes(targetWidgets);

--- a/malai-core/org.malai.ts/src/binding/Bindings.ts
+++ b/malai-core/org.malai.ts/src/binding/Bindings.ts
@@ -25,6 +25,7 @@ import {KeysData} from "../interaction/library/KeysData";
 import {KeyNodeBinder} from "./KeyNodeBinder";
 import {DnDBinder} from "./DnDBinder";
 import {SrcTgtPointsData} from "../interaction/library/SrcTgtPointsData";
+import {DragLockBinder} from "./DragLockBinder";
 
 /**
  * Creates binding builder to build a binding between a given interaction and the given command type.
@@ -63,9 +64,14 @@ export function anonCmdBinder<D extends InteractionData, I extends TSInteraction
     return new AnonCmdBinder(interaction, cmd);
 }
 
-export function dndBinder<D extends SrcTgtPointsData, C extends CommandImpl, I extends TSInteraction<D, FSM<Event>, {}>>
-    (cmdProducer: (i?: D) => C, srcOnUpdate: boolean, cancellable: boolean):  DnDBinder<C> {
+export function dndBinder<C extends CommandImpl>
+    (cmdProducer: (i?: SrcTgtPointsData) => C, srcOnUpdate: boolean, cancellable: boolean):  DnDBinder<C> {
     return new DnDBinder(cmdProducer, srcOnUpdate, cancellable);
+}
+
+export function dragLockBinder<C extends CommandImpl>
+    (cmdProducer: (i?: SrcTgtPointsData) => C):  DragLockBinder<C> {
+    return new DragLockBinder(cmdProducer);
 }
 
 /**

--- a/malai-core/org.malai.ts/src/binding/DragLockBinder.ts
+++ b/malai-core/org.malai.ts/src/binding/DragLockBinder.ts
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Malai.
+ * Copyright (c) 2009-2018 Arnaud BLOUIN Gwendal DIDOT
+ * Malai is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ * Malai is distributed without any warranty; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ */
+
+import {CommandImpl} from "../src-core/command/CommandImpl";
+import {SrcTgtPointsData} from "../interaction/library/SrcTgtPointsData";
+import {SourceTargetBinder} from "./SourceTargetBinder";
+import {DragLock} from "../interaction/library/DragLock";
+
+/**
+ * The binding builder to create bindings between a checkbox interaction and a given command.
+ * @param <C> The type of the command to produce.
+ * @author Gwendal Didot
+ */
+
+export class DragLockBinder<C extends CommandImpl> extends SourceTargetBinder<C, DragLock, SrcTgtPointsData, DragLockBinder<C>> {
+    public constructor (cmd: (i ?: SrcTgtPointsData) => C) {
+        super(new DragLock(), cmd);
+    }
+}

--- a/malai-core/org.malai.ts/src/interaction/library/DragLock.ts
+++ b/malai-core/org.malai.ts/src/interaction/library/DragLock.ts
@@ -134,7 +134,6 @@ export class DragLock extends TSInteraction<SrcTgtPointsData, DragLockFSM, Event
     }
 
     public reinitData(): void {
-        console.log("ReinitData DragLock");
         super.reinitData();
         this.firstClick.reinitData();
         this.sndClick.reinitData();

--- a/malai-core/org.malai.ts/test/binding/Bindings.test.ts
+++ b/malai-core/org.malai.ts/test/binding/Bindings.test.ts
@@ -9,7 +9,7 @@
  * General Public License for more details.
  */
 
-import {anonCmdBinder, buttonBinder, dndBinder, nodeBinder} from "../../src/binding/Bindings";
+import {anonCmdBinder, buttonBinder, dndBinder, dragLockBinder, nodeBinder} from "../../src/binding/Bindings";
 import {Click} from "../../src/interaction/library/Click";
 import {StubCmd} from "../command/StubCmd";
 import {AnonCmd, EventRegistrationToken, MArray} from "../../src";
@@ -81,5 +81,15 @@ test("Check if interaction successfully update on 'to' widget unless the interac
     canvas.dispatchEvent(createMouseEvent(EventRegistrationToken.MouseDown, canvas));
     button.dispatchEvent(createMouseEvent(EventRegistrationToken.MouseMove, button));
     button.dispatchEvent(createMouseEvent(EventRegistrationToken.MouseUp, button));
+    expect(StubCmd.prototype.doIt).toHaveBeenCalledTimes(1);
+});
+
+test("Check DragLockBinder", () => {
+    dragLockBinder(() => new StubCmd()).on(canvas).bind();
+    canvas.click();
+    canvas.click();
+    canvas.dispatchEvent(createMouseEvent(EventRegistrationToken.MouseMove, canvas));
+    canvas.click();
+    canvas.click();
     expect(StubCmd.prototype.doIt).toHaveBeenCalledTimes(1);
 });

--- a/malai-core/org.malai.ts/test/interaction/DragLock.test.ts
+++ b/malai-core/org.malai.ts/test/interaction/DragLock.test.ts
@@ -70,7 +70,6 @@ test("Drag lock canceled on ESC", () => {
 });
 
 test("Check data with a normal execution", () => {
-    //interaction.registerToNodes([canvas]);
     let srcX = -1;
     let srcY = -1;
     let tgtX = -1;
@@ -94,6 +93,9 @@ test("Check data with a normal execution", () => {
     expect(srcY).toBe(23);
     expect(tgtX).toBe(22);
     expect(tgtY).toBe(33);
+    expect(handler.fsmStarts).toHaveBeenCalledTimes(1);
+    expect(handler.fsmUpdates).toHaveBeenCalledTimes(2);
+    expect(handler.fsmStops).toHaveBeenCalledTimes(1);
     expect(handler.fsmCancels).not.toHaveBeenCalled();
 });
 

--- a/malai-core/org.malai.ts/test/interaction/DragLockSVGEnivronement.test.ts
+++ b/malai-core/org.malai.ts/test/interaction/DragLockSVGEnivronement.test.ts
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Malai.
+ * Copyright (c) 2009-2018 Arnaud BLOUIN
+ * Malai is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ * Malai is distributed without any warranty; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ */
+
+import {FSMHandler} from "../../src/src-core/fsm/FSMHandler";
+import {StubFSMHandler} from "../fsm/StubFSMHandler";
+import {DragLock} from "../../src/interaction/library/DragLock";
+import {createMouseEvent} from "./StubEvents";
+import {EventRegistrationToken} from "../../src/interaction/Events";
+
+jest.mock("../fsm/StubFSMHandler");
+
+let interaction: DragLock;
+let svg: SVGSVGElement;
+let handler: FSMHandler;
+let rect1 : SVGRectElement;
+let rect2 : SVGRectElement;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    handler = new StubFSMHandler();
+    interaction = new DragLock();
+    interaction.log(true);
+    interaction.getFsm().log(true);
+    interaction.getFsm().addHandler(handler);
+    document.documentElement.innerHTML = "<html></html>";
+    svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    document.body.appendChild(svg);
+    rect1 = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    rect2 = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    svg.appendChild(rect1);
+    svg.appendChild(rect2);
+});
+
+test("Test DragLock in a SVG environment", () => {
+    interaction.registerToNodes([rect1, rect2]);
+    rect2.dispatchEvent(createMouseEvent(EventRegistrationToken.Click, rect2));
+    rect2.dispatchEvent(createMouseEvent(EventRegistrationToken.Click, rect2));
+    rect2.dispatchEvent(createMouseEvent(EventRegistrationToken.MouseMove, rect2));
+    rect1.dispatchEvent(createMouseEvent(EventRegistrationToken.Click, rect1));
+    rect1.dispatchEvent(createMouseEvent(EventRegistrationToken.Click, rect1));
+    expect(handler.fsmStarts).toHaveBeenCalledTimes(1);
+    expect(handler.fsmUpdates).toHaveBeenCalledTimes(2);
+    expect(handler.fsmStops).toHaveBeenCalledTimes(1);
+    expect(handler.fsmCancels).not.toHaveBeenCalled();
+});
+
+test("Test DragLock data in a SVG environment", () => {
+    let srcX = -1;
+    let srcY = -1;
+    let tgtX = -1;
+    let tgtY = -1;
+    interaction.getFsm().addHandler(new class extends StubFSMHandler {
+
+        public fsmStops() {
+            srcX = interaction.getData().getSrcClientX();
+            srcY = interaction.getData().getSrcClientY();
+            tgtX = interaction.getData().getTgtClientX();
+            tgtY = interaction.getData().getTgtClientY();
+        }
+
+    }());
+    interaction.processEvent(createMouseEvent(EventRegistrationToken.Click, rect1, undefined, undefined, 11, 23));
+    interaction.processEvent(createMouseEvent(EventRegistrationToken.Click, rect1, undefined, undefined, 11, 23));
+    interaction.processEvent(createMouseEvent(EventRegistrationToken.MouseMove, svg, undefined, undefined, 20, 30));
+    interaction.processEvent(createMouseEvent(EventRegistrationToken.Click, rect2, undefined, undefined, 22, 33));
+    interaction.processEvent(createMouseEvent(EventRegistrationToken.Click, rect2, undefined, undefined, 22, 33));
+    expect(srcX).toBe(11);
+    expect(srcY).toBe(23);
+    expect(tgtX).toBe(22);
+    expect(tgtY).toBe(33);
+    expect(handler.fsmStarts).toHaveBeenCalledTimes(1);
+    expect(handler.fsmUpdates).toHaveBeenCalledTimes(2);
+    expect(handler.fsmStops).toHaveBeenCalledTimes(1);
+    expect(handler.fsmCancels).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
Changing how event are updated for additionalNodes children, and how additionalNodes are initialize in TSInteraction.
Also add little fix, a new DragLockBinder and new tests.