### PR TITLE
fix(ts): commands not accessible from the end and cancel binding routines 

### DIFF
--- a/malai-core/org.malai.ts/package.json
+++ b/malai-core/org.malai.ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "org.malai.ts",
+  "name": "org.malai.ts-dev",
   "description": "The typescript implementation of Malai (WIP)",
   "version": "3.1.0-alpha.1.2.8",
   "author": "Arnaud Blouin",

--- a/malai-core/org.malai.ts/package.json
+++ b/malai-core/org.malai.ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "org.malai.ts-dev",
+  "name": "org.malai.ts",
   "description": "The typescript implementation of Malai (WIP)",
   "version": "3.1.0-alpha.1.2.8",
   "author": "Arnaud Blouin",

--- a/malai-core/org.malai.ts/src/binding/AnonNodeBinding.ts
+++ b/malai-core/org.malai.ts/src/binding/AnonNodeBinding.ts
@@ -109,10 +109,10 @@ export class AnonNodeBinding<C extends CommandImpl, I extends TSInteraction<D, F
     }
 
     public fsmCancels(): void {
-        if (this.endOrCancelFct && this.cmd !== undefined) {
+        if (this.endOrCancelFct !== undefined && this.cmd !== undefined) {
             this.endOrCancelFct(this.interaction.getData(), this.cmd);
         }
-        if (this.cancelFct && this.cmd !== undefined) {
+        if (this.cancelFct !== undefined && this.cmd !== undefined) {
             this.cancelFct(this.interaction.getData(), this.cmd);
         }
         super.fsmCancels();

--- a/malai-core/org.malai.ts/src/binding/AnonNodeBinding.ts
+++ b/malai-core/org.malai.ts/src/binding/AnonNodeBinding.ts
@@ -101,15 +101,11 @@ export class AnonNodeBinding<C extends CommandImpl, I extends TSInteraction<D, F
     }
 
     public first(): void {
-        if (this.currentCmd !== undefined) {
-            this.execInitCmd(this.getInteraction().getData(), this.getCommand());
-        }
+        this.execInitCmd(this.getInteraction().getData(), this.getCommand());
     }
 
     public then(): void {
-        if (this.currentCmd !== undefined) {
-            this.execUpdateCmd(this.getInteraction().getData(), this.getCommand());
-        }
+        this.execUpdateCmd(this.getInteraction().getData(), this.getCommand());
     }
 
     public when(): boolean {

--- a/malai-core/org.malai.ts/src/src-core/binding/WidgetBindingImpl.ts
+++ b/malai-core/org.malai.ts/src/src-core/binding/WidgetBindingImpl.ts
@@ -63,7 +63,7 @@ export abstract class WidgetBindingImpl<C extends CommandImpl, I extends Interac
     /**
      * The command class to instantiate.
      */
-    private readonly cmdProducer: (i?: D) => C;
+    protected readonly cmdProducer: (i?: D) => C;
 
     protected constructor(exec: boolean, interaction: I, cmdProducer: (i?: D) => C) {
         this.execute = false;

--- a/malai-core/org.malai.ts/test/binding/Bindings.test.ts
+++ b/malai-core/org.malai.ts/test/binding/Bindings.test.ts
@@ -93,3 +93,9 @@ test("Check DragLockBinder", () => {
     canvas.click();
     expect(StubCmd.prototype.doIt).toHaveBeenCalledTimes(1);
 });
+
+test("Test the end() routine", () => {
+    buttonBinder(i => new StubCmd()).on(button).end(i => expect(i.getWidget()).not.toBe(undefined)).bind();
+    button.click();
+    expect(StubCmd.prototype.doIt).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
Remove currentCommand because it's not longer needed.
Rework fsmStops and fsmCancels for AnonNodeBinding